### PR TITLE
Improve tools

### DIFF
--- a/env/src/tools/agent/extract_item/client.py
+++ b/env/src/tools/agent/extract_item/client.py
@@ -7,11 +7,12 @@ from tools.tool import Tool
 
 
 class ExtractItem(Tool):
-
     def __init__(self, connection, game_state):
         super().__init__(connection, game_state)
 
-    def __call__(self, entity: Prototype, source: Union[Position, Entity], quantity=5) -> int:
+    def __call__(
+        self, entity: Prototype, source: Union[Position, Entity], quantity=5
+    ) -> int:
         """
         Extract an item from an entity's inventory at position (x, y) if it exists on the world.
         :param entity: Entity prototype to extract, e.g Prototype.IronPlate
@@ -35,11 +36,14 @@ class ExtractItem(Tool):
         if isinstance(response, str):
             msg = self.get_error_message(response)
             if source_name:
-                raise Exception(f"Could not extract {name} from {source_name} at ({x}, {y}): {msg}")
+                raise Exception(
+                    f"Could not extract {name} from {source_name} at ({x}, {y}): {msg}"
+                )
             else:
                 raise Exception(f"Could not extract {name} at ({x}, {y}): {msg}")
 
         if not response or response < 1:
-            raise Exception("Could not extract.")
+            # raise Exception("Could not extract.")
+            raise Exception("Could not extract: your inventory is full.")
 
         return response

--- a/env/src/tools/agent/nearest/server.lua
+++ b/env/src/tools/agent/nearest/server.lua
@@ -15,12 +15,21 @@ global.actions.nearest = function(player_index, resource)
 
     local normalized_resource = normalize_resource_name(resource)
 
+    local function shuffle_table(tbl)
+        for i = #tbl, 2, -1 do
+            local j = math.random(i)
+            tbl[i], tbl[j] = tbl[j], tbl[i]
+        end
+        return tbl
+    end
+
     local function find_nearest(player, resource)
         local surface = player.surface
         local position = player.position
         local closest_distance = math.huge
         local closest = nil
         local entities
+        math.randomseed(game.tick)
 
         if resource == "wood" then
             entities = surface.find_entities_filtered{
@@ -32,9 +41,10 @@ global.actions.nearest = function(player_index, resource)
                 area = {{position.x - 500, position.y - 500}, {position.x + 500, position.y + 500}},
                 name = "water"
             }
+            water_positions = shuffle_table(water_positions)
             for _, water_tile in ipairs(water_positions) do
                 local distance = ((position.x - water_tile.position.x) ^ 2 + (position.y - water_tile.position.y) ^ 2) ^ 0.5
-                if distance < closest_distance then
+                if distance < closest_distance * 1.1 then
                     closest_distance = distance
                     closest = water_tile.position
                 end
@@ -51,9 +61,10 @@ global.actions.nearest = function(player_index, resource)
             }
         end
 
+        entities = shuffle_table(entities)
         for _, entity in ipairs(entities) do
             local distance = ((position.x - entity.position.x) ^ 2 + (position.y - entity.position.y) ^ 2) ^ 0.5
-            if distance < closest_distance then
+            if distance < closest_distance * 1.1 then
                 closest_distance = distance
                 closest = entity.position
             end


### PR DESCRIPTION
- nearestでデッドロックを防ぐため、乱数要素を入れる
- extract_itemでインベントリがフルの時のエラーメッセージを改善